### PR TITLE
Update automod.py

### DIFF
--- a/discord/automod.py
+++ b/discord/automod.py
@@ -405,7 +405,7 @@ class AutoModTriggerMetadata:
                 yield keyword
 
     def to_dict(self) -> Dict[str, Any]:
-        if self.keyword_filter:
+        if self.keyword_filter or self._regex_patterns:
             base = {
                 'keyword_filter': self.keyword_filter,
                 'regex_patterns': [


### PR DESCRIPTION
Fixed AutoModTriggerMetadata.to_dict() because if you only provided regex_patterns it would return None. Now it doesnt.