### PR TITLE
Fix missing embeds parameter

### DIFF
--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -810,6 +810,7 @@ class BaseInteraction:
                 content=content,
                 flags=flags,
                 embed=embed,
+                embeds=embeds,
                 attachments=attachments,
                 components=components,
                 allowed_mentions=allowed_mentions,


### PR DESCRIPTION
This PR fixes the missing `embeds` parameter thats not passed through the handle_interaction_message_parameters function correctly. 