### PR TITLE
Add premium button

### DIFF
--- a/discord/components.py
+++ b/discord/components.py
@@ -185,7 +185,7 @@ class Button(BaseComponent):
         url: Optional[:class:`str`]
             An URL for the button if it is of type :attr:`ButtonStyle.url`
         sku_id: Optional[:class:`int`]
-            The purchasable SKU's identifier when using :attr:`~discord.ButtonStyle.Premium`. Note that a premium
+            The purchasable SKU's identifier when using :attr:`ButtonStyle.Premium`. Note that a premium
             button can **only** have this attribute as well as :attr:`Button.disabled` set and can **not** have a
             custom_id, label, url or emoji.
         """
@@ -281,6 +281,9 @@ class Button(BaseComponent):
 
     @property
     def sku_id(self) -> Optional[int]:
+        """
+        Optional[:class:`int`]: The purchasable SKU's identifier when :attr:`~Button.style` is set to :attr:`ButtonStyle.Premium`
+        """
         return self._sku_id
 
     @sku_id.setter
@@ -412,10 +415,11 @@ class Button(BaseComponent):
     def to_dict(self) -> ButtonPayload:
         base = {
             'type': 2,
-            'label': self.label,
             'style': int(self.style),
             'disabled': self.disabled
         }
+        if self.label:
+            base['label'] = self.label
         if self.custom_id is not None:
             base['custom_id'] = str(self.custom_id)
         elif self.url:
@@ -424,7 +428,6 @@ class Button(BaseComponent):
             base['emoji'] = self.emoji.to_dict()
         if self.sku_id:
             base['sku_id'] = str(self.sku_id)
-            del base['label']
         return base
     
     @classmethod
@@ -438,7 +441,8 @@ class Button(BaseComponent):
             custom_id=data.get('custom_id'),
             style=data['style'],
             url=data.get('url'),
-            disabled=data.get('disabled', False)
+            disabled=data.get('disabled', False),
+            sku_id=data.gat('sku_id'),
         )
 
 

--- a/discord/components.py
+++ b/discord/components.py
@@ -157,7 +157,7 @@ class BaseComponent:
 
 class Button(BaseComponent):
     """Represents a `Discord-Button <https://discord.com/developers/docs/interactions/message-components#button-object>`_"""
-    __slots__ = ('_label', '_custom_id', '_style', '_url', '_disabled')
+    __slots__ = ('_label', '_custom_id', '_style', '_url', '_disabled', '_sku_id')
 
     def __init__(
             self,
@@ -166,6 +166,7 @@ class Button(BaseComponent):
             style: Union[ButtonStyle, int] = ButtonStyle.grey,
             emoji: Union[PartialEmoji, Emoji, str] = None,
             url: Optional[str] = None,
+            sku_id: Optional[int] = None,
             disabled: bool = False
     ) -> None:
         """
@@ -183,22 +184,36 @@ class Button(BaseComponent):
             An emoji that will be displayed on the left side of the button.
         url: Optional[:class:`str`]
             An URL for the button if it is of type :attr:`ButtonStyle.url`
+        sku_id: Optional[:class:`int`]
+            The purchasable SKU's identifier when using :attr:`~discord.ButtonStyle.Premium`. Note that a premium
+            button can **only** have this attribute as well as :attr:`Button.disabled` set and can **not** have a
+            custom_id, label, url or emoji.
         """
         super().__init__(custom_id=custom_id, disabled=disabled)
         self.style: ButtonStyle = try_enum(ButtonStyle, style)
-        if not emoji and not label:
-            raise InvalidArgument('A button must have at least one of label or emoji set')
+        if self.style.Premium and not sku_id:
+            raise InvalidArgument("An sku_id must be specified for premium buttons")
+        elif sku_id and not self.style.Premium:
+            raise InvalidArgument("sku_id can only be used with discord.ButtonStyle.premium")
+        elif sku_id and any((label, custom_id, emoji, url,)):
+            raise InvalidArgument('A premium button can only have parameters sku_id and (optionally) disabled')
+
+        if not emoji and not label and not self.style.Premium:
+            raise InvalidArgument('Non-premium buttons must have at least one of label or emoji set')
         elif self.style.url and not url:
             raise InvalidArgument('An url is required for url buttons')
         elif url and not self.style.url:
             self.style = ButtonStyle.url
+
         if url and custom_id:
             raise URLAndCustomIDNotAlowed(self.custom_id)
-        elif not url and custom_id is None:
-            raise InvalidArgument('A custom_id must be specified for non-url buttons')
+        elif not url and custom_id is None and not sku_id:
+            raise InvalidArgument('A custom_id must be specified for non-url and non-premium buttons')
+
         self.url: Optional[str] = url
         self.label: str = label
         self.emoji = emoji
+        self.sku_id = sku_id
 
     def __repr__(self) -> str:
         return f'<Button {", ".join(["%s=%s" % (k, str(v)) for k, v in self.__dict__.items()])}>'
@@ -263,6 +278,14 @@ class Button(BaseComponent):
         if value and not value.startswith(('http://', 'https://', 'discord://')):
             raise ValueError(f'"{value}" is not a valid protocol. Only http(s) or discord protocol is supported')
         self._url = value
+
+    @property
+    def sku_id(self) -> Optional[int]:
+        return self._sku_id
+
+    @sku_id.setter
+    def sku_id(self, value: Optional[int]):
+        self._sku_id = value
 
     @utils.deprecated('label setter')
     def set_label(self, label: str):
@@ -399,6 +422,9 @@ class Button(BaseComponent):
             base['url'] = self.url
         if self.emoji:
             base['emoji'] = self.emoji.to_dict()
+        if self.sku_id:
+            base['sku_id'] = str(self.sku_id)
+            del base['label']
         return base
     
     @classmethod

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -360,6 +360,7 @@ class ButtonStyle(Enum):
     grey_url    = 5
     gray_url    = 5
     Link_Button = 5
+    Premium     = 6
 
     @classmethod
     def from_value(cls, value):

--- a/discord/types/message.py
+++ b/discord/types/message.py
@@ -67,7 +67,7 @@ __all__ = (
 
 
 ComponentType = Literal[1, 2, 3, 4, 5, 6, 7, 8]
-ButtonStyle = Literal[1, 2, 3, 4, 5]
+ButtonStyle = Literal[1, 2, 3, 4, 5, 6]
 TextInputStyle = Literal[1, 2]
 SelectDefaultValueType = Literal['user', 'role', 'channel']
 MessageType = Literal[

--- a/discord/types/message.py
+++ b/discord/types/message.py
@@ -122,6 +122,7 @@ class Button(TypedDict):
     custom_id: NotRequired[str]
     url: NotRequired[str]
     disabled: NotRequired[bool]
+    sku_id: NotRequired[int]
 
 
 class DefaultValue(TypedDict):


### PR DESCRIPTION
This commit adds discord.ButtonStyle.Premium and the corresponing changes for the discord.Button class.
I couldn't really test this any further as to the point where I could send a call to Discord's API with all the necessary parameters, but since I don't have access to an app with SUKs, I don't know if this _actually_ works.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request adds support for a new premium button style in Discord buttons, including the necessary changes to the Button class to handle SKU identifiers and enforce validation rules.

- **New Features**:
    - Introduced a new ButtonStyle.Premium for Discord buttons, allowing the creation of premium buttons with SKU identifiers.
- **Enhancements**:
    - Updated the Button class to support the new premium button style, including validation rules for SKU identifiers and other button attributes.

<!-- Generated by sourcery-ai[bot]: end summary -->